### PR TITLE
[refactoring] add throw when factory getCommand receives wrong command

### DIFF
--- a/test-shell/command_factory.cpp
+++ b/test-shell/command_factory.cpp
@@ -17,7 +17,12 @@ public:
 	}
 
 	ICommand* getCommand(const string& command) override {
-		return commands[command];
+		if (commands.count(command) == 1) {
+			return commands[command];
+		}
+		else {
+			throw std::invalid_argument("getCommand: cannot find" + command);
+		}
 	}
 
 	const std::unordered_map<std::string, ICommand*>& getAllCommands() const override {

--- a/unit-test/test_factory.cpp
+++ b/unit-test/test_factory.cpp
@@ -67,6 +67,10 @@ TEST_F(FactoryFixture, TestInjectedWriteCommand) {
 	command->execute(dummy_args);
 }
 
+TEST_F(FactoryFixture, TestThrowgetCommand) {
+	EXPECT_THROW(factory.getCommand("test"), std::invalid_argument);
+}
+
 TEST_F(FactoryFixture, TestgetAllCommands) {
 	EXPECT_CALL(readCMD, execute(_))
 		.Times(1);


### PR DESCRIPTION
## 제목
1. 상태 정보
  - [ ] feature
  - [x] refactoring
  - [ ] hotfix


2. 반영 내용
- 잘못된 명령어를 넣을경우 에러를 던지도록 factory 수정하였습니다.
-
-


3. Unit Test
- [x] 추가된 TC 여부 : <추가된 경우 TC명>
TestThrowgetCommand
- [x] Unit Test 전체 Pass 여부
