### PR TITLE
change cpp standard to 17 and fix build failure

### DIFF
--- a/dummy/dummy.vcxproj
+++ b/dummy/dummy.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/logger/logger.vcxproj
+++ b/logger/logger.vcxproj
@@ -119,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/test-shell/ssdlib.cpp
+++ b/test-shell/ssdlib.cpp
@@ -1,25 +1,25 @@
 #include <iostream>
-#include <windows.h>
 #include <string>
 #include <fstream>
 #include "ssd.h"
+#include <filesystem>
 
 class SSDLib : public ISSD {
 public:
 	SSDLib() {
-		GetCurrentDirectoryA(256, current_path);
+		current_path = std::filesystem::current_path();
 	}
 
 	SSDLib(const std::string& directory_path)
 		: directory_path { directory_path } {
-		GetCurrentDirectoryA(256, current_path);
+		current_path = std::filesystem::current_path();
 	}
 
 	SSDLib(const std::string& directory_path,
 		const std::string& app_name)
 		: directory_path{ directory_path }
 		, app_name{ app_name } {
-		GetCurrentDirectoryA(256, current_path);
+		current_path = std::filesystem::current_path();
 	}
 
 	SSDLib(const std::string& directory_path,
@@ -28,27 +28,27 @@ public:
 		: directory_path{ directory_path }
 		, app_name{ app_name } 
 		, result_path{ result_path } {
-		GetCurrentDirectoryA(256, current_path);
+		current_path = std::filesystem::current_path();
 	}
 
 	void write(int addr, const std::string& value) override {
-		std::string command = std::string(current_path) + 
+		std::string command = current_path.string() +
 			directory_path + app_name + " W " +
 			std::to_string(addr) + " " + value;
 		system(command.c_str());
 	}
 
 	std::string read(int addr) override {
-		std::string command = std::string(current_path) +
+		std::string command = current_path.string() +
 			directory_path + app_name + " R " +
 			std::to_string(addr);
 		system(command.c_str());
-		return getValue(std::string(current_path) + result_path +
+		return getValue(current_path.string() + result_path +
 						result_name);
 	}
 
 private:
-	char current_path[256];
+	std::filesystem::path current_path;
 	std::string directory_path = "\\..\\x64\\Debug";
 	std::string app_name = "\\ssd.exe";
 	std::string result_path = "";

--- a/test-shell/test-shell.vcxproj
+++ b/test-shell/test-shell.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/unit-test/unit-test.vcxproj
+++ b/unit-test/unit-test.vcxproj
@@ -57,6 +57,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -87,6 +88,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
## 제목
1. 상태 정보
  - [ ] feature
  - [x] refactoring
  - [ ] hotfix


2. 반영 내용
- cpp 표준을 14에서 17로 변경하고 이로인한 빌드실패 수정하였습니다.
-
-


3. Unit Test
- [ ] 추가된 TC 여부 : <추가된 경우 TC명>
- [x] Unit Test 전체 Pass 여부
