### PR TITLE
fix logger unit test failure

### DIFF
--- a/logger/ILogger.h
+++ b/logger/ILogger.h
@@ -12,4 +12,5 @@ public:
 	virtual void printLog(PRINT_TYPE type,
 		const std::string& func_name,
 		const std::string& message) = 0;
+	virtual void setDirectory(const std::string& log_directory) = 0;
 };

--- a/logger/Logger.cpp
+++ b/logger/Logger.cpp
@@ -7,6 +7,10 @@
 #include <fstream>
 
 Logger::Logger(const std::string& log_directory) {
+	setDirectory(log_directory);
+}
+
+void Logger::setDirectory(const std::string& log_directory) {
 	m_log_directory = log_directory;
 	if (std::filesystem::exists(m_log_directory)) {
 		std::filesystem::remove_all(m_log_directory);

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -9,6 +9,7 @@ public:
 		const std::string& func_name,
 		const std::string& message) override;
 
+	void setDirectory(const std::string& log_directory) override;
 
 private:
 	Logger(const std::string& log_directory);

--- a/unit-test/test_logger.cpp
+++ b/unit-test/test_logger.cpp
@@ -7,8 +7,8 @@
 
 class LoggerFixture : public ::testing::Test {
 public:
-	std::string module_name = "gtest";
-	ILogger& logger = Logger::getInstance(module_name);
+	std::string log_directory = "gtest";
+	ILogger& logger = Logger::getInstance(log_directory);
 	std::string name = "func()";
 	std::string msg = "test message";
 	const int m_name_buffer = 30;
@@ -34,6 +34,11 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+protected:
+	void SetUp() override {
+		logger.setDirectory(log_directory);
 	}
 
 private:
@@ -64,7 +69,7 @@ TEST_F(LoggerFixture, FileTest) {
 	
 	std::vector<std::string> file_names;
 	for (const auto& dir_entry : 
-		std::filesystem::directory_iterator{ module_name }) {
+		std::filesystem::directory_iterator{ log_directory }) {
 		file_names.push_back(dir_entry.path().string());
 	}
 	EXPECT_TRUE(checkFiles(file_names));


### PR DESCRIPTION
## 제목
1. 상태 정보
  - [ ] feature
  - [ ] refactoring
  - [x] hotfix


2. 반영 내용
- unit-test에서는 ssd 와 test-shell이 같은 singletone logger를 공유하여 로그폴더가 같아지는 문제가 발생하였습니다.
- 이부분을 setDirectory함수 추가하여 수정하였습니다.
-


3. Unit Test
- [ ] 추가된 TC 여부 : <추가된 경우 TC명>
- [x] Unit Test 전체 Pass 여부
