### PR TITLE
hotfix/ssd-erase-range

### DIFF
--- a/ssd/CommandBuffer.cpp
+++ b/ssd/CommandBuffer.cpp
@@ -99,7 +99,7 @@ bool CommandBuffer::searchPassedLatestDataForRead(int lba)
 		}
 		else if (cmdList[i].opcode == ERASE_CMD)
 		{
-			if (true == IsEraseLbaRangeIncluded(lba, cmdList[i].lba, stoi(cmdList[i].data)))
+			if (true == IsEraseLbaRangeIncluded(lba, cmdList[i].lba, cmdList[i].lba + stoi(cmdList[i].data)))
 			{
 				data = INIT_DATA;
 				searchResult = true;


### PR DESCRIPTION
## hotfix/ssd-erase-range
1. 상태 정보
  - [ ] feature
  - [ ] refactoring
  - [x] hotfix


2. 반영 내용
- read시 cache에서 erase range 체크 하도록 조건문 수정
-
-


3. Unit Test
- [ ] 추가된 TC 여부 : <추가된 경우 TC명>
- [ ] Unit Test 전체 Pass 여부
