### PR TITLE
fix logger: now ssd log remain until program lifetime

### DIFF
--- a/logger/ILogger.h
+++ b/logger/ILogger.h
@@ -12,5 +12,5 @@ public:
 	virtual void printLog(PRINT_TYPE type,
 		const std::string& func_name,
 		const std::string& message) = 0;
-	virtual void setDirectory(const std::string& log_directory) = 0;
+	virtual void resetDirectory(const std::string& log_directory) = 0;
 };

--- a/logger/Logger.cpp
+++ b/logger/Logger.cpp
@@ -7,18 +7,18 @@
 #include <fstream>
 
 Logger::Logger(const std::string& log_directory) {
-	setDirectory(log_directory);
-}
-
-void Logger::setDirectory(const std::string& log_directory) {
 	m_log_directory = log_directory;
-	if (std::filesystem::exists(m_log_directory)) {
-		std::filesystem::remove_all(m_log_directory);
-	}
 	std::filesystem::create_directory(m_log_directory);
 }
 
-Logger& Logger::getInstance(const std::string& log_directory) {
+void Logger::resetDirectory(const std::string& log_directory) {
+	if (std::filesystem::exists(log_directory)) {
+		std::filesystem::remove_all(log_directory);
+	}
+	std::filesystem::create_directory(log_directory);
+}
+
+ILogger& Logger::getInstance(const std::string& log_directory) {
 	static Logger instance(log_directory);
 	return instance;
 }

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -3,13 +3,13 @@
 
 class Logger : public ILogger {
 public:
-	static Logger& getInstance(const std::string& log_directory);
+	static ILogger& getInstance(const std::string& log_directory);
 
 	void printLog(PRINT_TYPE type,
 		const std::string& func_name,
 		const std::string& message) override;
 
-	void setDirectory(const std::string& log_directory) override;
+	void resetDirectory(const std::string& log_directory) override;
 
 private:
 	Logger(const std::string& log_directory);

--- a/test-shell/shell.cpp
+++ b/test-shell/shell.cpp
@@ -11,6 +11,8 @@ Shell::Shell(ICommandFactory& factory)
 	: _factory { factory }
 	, logger{ Logger::getInstance("shell") }
 {
+	logger.resetDirectory("shell");
+	logger.resetDirectory("ssd");
 }
 
 inline string Shell::waitForCommand() {

--- a/unit-test/test_logger.cpp
+++ b/unit-test/test_logger.cpp
@@ -1,13 +1,13 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "../logger/Logger.cpp"
 #include <filesystem>
 #include <vector>
 #include <fstream>
+#include "../logger/Logger.h"
 
 class LoggerFixture : public ::testing::Test {
 public:
-	std::string log_directory = "gtest";
+	std::string log_directory = "ssd";
 	ILogger& logger = Logger::getInstance(log_directory);
 	std::string name = "func()";
 	std::string msg = "test message";
@@ -38,7 +38,7 @@ public:
 
 protected:
 	void SetUp() override {
-		logger.setDirectory(log_directory);
+		logger.resetDirectory(log_directory);
 	}
 
 private:
@@ -69,7 +69,6 @@ TEST_F(LoggerFixture, LongFuncNameTest) {
 	std::string captured_out = testing::internal::GetCapturedStdout();
 	size_t begin_idx = captured_out.find_last_of(")");
 	size_t end_idx = captured_out.find_last_of(":");
-	std::cout << captured_out << std::endl;
 	EXPECT_EQ(end_idx - begin_idx - 1, 0);
 }
 

--- a/unit-test/test_main.cpp
+++ b/unit-test/test_main.cpp
@@ -22,3 +22,5 @@
 #include "../ssd/ReadCmdHandler.cpp"
 #include "../ssd/EraseCmdHandler.cpp"
 #include "../ssd/FlushCmdHandler.cpp"
+
+#include "../logger/Logger.cpp"


### PR DESCRIPTION
## 제목
1. 상태 정보
  - [ ] feature
  - [ ] refactoring
  - [x] hotfix


2. 반영 내용
- ssd가 shell에서 호출될때마다 생성과 소멸이 반복되는데 이로인해 ssd 로그 폴더가 초기화되어 로그 분석이 어려운점이 발견되었습니다. 이부분 수정하였습니다.
-
-


3. Unit Test
- [ ] 추가된 TC 여부 : <추가된 경우 TC명>
- [ ] Unit Test 전체 Pass 여부
