### PR TITLE
[hotifx] script launcher n회 실행시 verify fail issue

### DIFF
--- a/test-shell/ScriptLauncher.cpp
+++ b/test-shell/ScriptLauncher.cpp
@@ -152,6 +152,7 @@ ScriptLauncher::Invoker::Invoker()
 
 void ScriptLauncher::Invoker::beginStreamCapture()
 {
+	_osstream = {};
 	_befoBuffer = cout.rdbuf();
 	cout.set_rdbuf(_osstream.rdbuf());
 }

--- a/unit-test/test_shell_script.cpp
+++ b/unit-test/test_shell_script.cpp
@@ -41,16 +41,15 @@ protected:
 	void SetUp() override {
 		factory.injectCommand("read", &readCommad);
 		factory.injectCommand("write", &writeCommad);
-
-		EXPECT_CALL(ssd, write(_, _))
-			.Times(10);
 	}
 };
 
 
 TEST_F(ScriptLauncherFixture, TestScript1_NORMAL) {
+	EXPECT_CALL(ssd, write(_, _))
+		.Times(20);
 	EXPECT_CALL(ssd, read(_))
-		.Times(5)
+		.Times(10)
 		.WillRepeatedly(Return("0xAAAABBBB"));
 	
 	EXPECT_NO_THROW(launcher.compile());
@@ -59,11 +58,14 @@ TEST_F(ScriptLauncherFixture, TestScript1_NORMAL) {
 	internal::CaptureStdout();
 
 	EXPECT_NO_THROW(launcher.execute({}));
+	EXPECT_NO_THROW(launcher.execute({}));
 
-	EXPECT_EQ(internal::GetCapturedStdout(), "TestScript1 --- Run...Pass\n");
+	EXPECT_EQ(internal::GetCapturedStdout(), "TestScript1 --- Run...Pass\nTestScript1 --- Run...Pass\n");
 }
 
 TEST_F(ScriptLauncherFixture, TestScript1_VERIFY_FAIL) {
+	EXPECT_CALL(ssd, write(_, _))
+		.Times(10);
 	EXPECT_CALL(ssd, read(_))
 		.Times(3)
 		.WillRepeatedly(Return("0xAAAAAAAA"));


### PR DESCRIPTION
## script launcher n회 실행시 verify fail issue
1. 상태 정보
  - [ ] feature
  - [ ] refactoring
  - [x] hotfix


2. 반영 내용
- 표준 출력 캡쳐 스트림 초기화 반영
-
-


3. Unit Test
- [x] 추가된 TC 여부 : ScriptLauncherFixture, TestScript1_NORMAL 에서 2회 연달아 Pass Check 하도록 반영
- [x] Unit Test 전체 Pass 여부
